### PR TITLE
MOVEMENT RAHH

### DIFF
--- a/characters/character.cc
+++ b/characters/character.cc
@@ -13,3 +13,14 @@ void Character::addToHp(int n) {
 void Character::subtractFromHp(int n) {
     hp -= n;
 }
+
+// Moves the character without performing any checks
+// Precondition: The tile you are trying to move to must be empty or else memory leak
+void Character::moveNoChecks(Direction d, Tile& tile){
+    auto neighbours = tile.getNeighbours();
+    Tile* target = neighbours[d];
+    target->setEntity(this);
+    tile.setEntity(nullptr);
+    this->detach(&tile);
+    this->attach(target);
+}

--- a/characters/character.h
+++ b/characters/character.h
@@ -9,7 +9,8 @@ class Character : public Entity {
     const int atk;
     const int def;
     int hp;
-
+protected:
+    void moveNoChecks(Direction d, Tile& tile);
 public:
     Character(char c, int maxHp, int atk, int def);
     int getHp();
@@ -17,6 +18,7 @@ public:
     void subtractFromHp(int n);
 
     virtual void attack(Direction d, Tile& tile) = 0;
-    virtual void move(Direction d, Tile& tile) = 0;
+    // move should return a bool indicating success and a string for what happened
+    virtual pair<bool, string> move(Direction d, Tile& tile) = 0;
 };
 #endif

--- a/characters/enemies/dragon.cc
+++ b/characters/enemies/dragon.cc
@@ -7,4 +7,4 @@ Dragon::Dragon(bool hasCompass, Item* ownedItem) : Enemy{ 'D', 150, 20, 20, hasC
 void Dragon::onDeath() {}
 
 // dragon does not move, so this does nothing
-void Dragon::move(Direction d, Tile& t) {}
+pair<bool, string> Dragon::move(Direction d, Tile& t) {}

--- a/characters/enemies/dragon.h
+++ b/characters/enemies/dragon.h
@@ -8,6 +8,6 @@ public:
     Dragon(bool hasCompass, Item* ownedItem);
     void onDeath();
 public:
-    void move(Direction d, Tile& t);
+    pair<bool, string> move(Direction d, Tile& t);
 };
 #endif

--- a/characters/enemy.cc
+++ b/characters/enemy.cc
@@ -14,4 +14,4 @@ void Enemy::onDeath() {
 void Enemy::endOfTurnEffect(Tile& t) {}
 
 void Enemy::attack(Direction d, Tile& tile) {}
-void Enemy::move(Direction d, Tile& tile) {}
+pair<bool, string> Enemy::move(Direction d, Tile& tile) {}

--- a/characters/enemy.h
+++ b/characters/enemy.h
@@ -16,7 +16,7 @@ public:
     void endOfTurnEffect(Tile& t);
 
     Enemy(char c, int maxHp, int atk, int def, bool hasCompass, int goldDrop, Item* ownedItem = nullptr);
-    void attack(Direction d, Tile& tile);
-    void move(Direction d, Tile& tile);
+    virtual void attack(Direction d, Tile& tile) override;
+    virtual pair<bool, string> move(Direction d, Tile& tile) override;
 };
 #endif

--- a/characters/player.cc
+++ b/characters/player.cc
@@ -1,4 +1,5 @@
 #include "player.h"
+#include "items/steppableItem.h"
 
 Player::Player(char c, int maxHp, int atk, int def, int hp): Character{c, maxHp, atk, def}, hp{hp}{}
 
@@ -8,11 +9,11 @@ void Player::applyPotion(Potionfx* p){
 }
 
 int Player::getAttack(){
-    return atk + pfx->getAtkChange();
+    return pfx ? atk + pfx->getAtkChange(): atk;
 }
 
 int Player::getDefense(){
-    return def + pfx->getDefChange();
+    return pfx ? def + pfx->getDefChange(): def;
 }
 
 float Player::getGold(){
@@ -47,11 +48,32 @@ float Player::calculateScore(){
     return totGold;
 }
 
-void Player::use(pair<int, int> pcoords, Tile& t){
+void Player::use(Direction d, Tile& tile){
     
 }
 
 void Player::attack(Direction d, Tile& tile){}
-void Player::move(Direction d, Tile& tile){}
+pair<bool, string> Player::move(Direction d, Tile& tile){
+    auto neighbours = tile.getNeighbours();
+    Tile* target = neighbours[d];
+    if(target->isPassable()){
+        //cout << "target is passable" << endl;
+        //the only passable tiles are those that are empty or have a steppable item on them. Technically if the entity exists we know its a steppable item but we check anyways
+        Entity* targetEntity = target->getEntity();
+
+        // check if empty or if its a steppable item
+        if (targetEntity == nullptr){
+            //cout << "entity is null" << endl;
+        }
+        else if(SteppableItem* sItemPtr = dynamic_cast<SteppableItem*>(targetEntity)){
+            sItemPtr->onStepped(*this);
+        }
+        moveNoChecks(d, tile);
+        return make_pair(true, "Player successfully moved \n");
+    }
+    else{
+        return make_pair(false, "Player tried to move but failed \n");
+    }
+}
 
 void Player::onDeath(){}

--- a/characters/player.h
+++ b/characters/player.h
@@ -30,9 +30,9 @@ class Player : public Character {
     void resetTempFx();
     void gainBarrierSuit();
     virtual float calculateScore();
-    void use(pair<int, int> pcoords, Tile& t);
-    void attack(Direction d, Tile& tile);
-    void move(Direction d, Tile& tile);
+    void use(Direction d, Tile& tile);
+    virtual void attack(Direction d, Tile& tile) override;
+    virtual pair<bool, string> move(Direction d, Tile& tile) override;
 };
 
 #endif

--- a/entity.cc
+++ b/entity.cc
@@ -1,4 +1,5 @@
 #include "entity.h"
+#include <algorithm>
 
     Entity::Entity(char c): c{c}{}
 
@@ -11,6 +12,7 @@
     }
 
     bool Entity::isPassable(){
+        return false;
     }
 
     void Entity::onDeath(){}
@@ -24,7 +26,9 @@
         observers.emplace_back(t);
     }
 
-    void Entity::detach(Tile* t){}
+    void Entity::detach(Tile* t){
+        observers.erase(remove(observers.begin(), observers.end(), t), observers.end());
+    }
 
     void Entity::notifyObservers(){
         for(auto p: observers) p->notify();

--- a/game.cc
+++ b/game.cc
@@ -28,7 +28,6 @@ void Game::start() {
         }
         else {
             string actionString = gm.playerTurn(c);
-            actionString = "this is the string for the action the player has performed";
             render(actionString);
         }
     }

--- a/gameModel.cc
+++ b/gameModel.cc
@@ -255,6 +255,9 @@ pair<int, int> GameModel::addToRandomTile(Entity* e, bool canBeWithPlayer) {
     }
 
     map[p.first][p.second].setEntity(e);
+    if (e){
+        e->attach(&map[p.first][p.second]);
+    }
     return p;
 }
 
@@ -304,7 +307,11 @@ vector<Direction> GameModel::getGameDirections() {
 }
 
 Player* GameModel::getPlayer() {
-    return static_cast<Player*>(map[playerCoords.first][playerCoords.second].getEntity());
+    return static_cast<Player*>(getPlayerTile().getEntity());
+}
+
+Tile& GameModel::getPlayerTile(){
+    return map[playerCoords.first][playerCoords.second];
 }
 
 int GameModel::getFloor() {
@@ -312,6 +319,16 @@ int GameModel::getFloor() {
 }
 
 string GameModel::playerTurn(Command c) {
-    // move,, attack, use , etc depending on the command. Return the string saying what happened i.e 'Player moves East'
-    return "test action";
+    switch (c.action)
+    {
+        case Action::MOVE:{
+            auto p = getPlayer()->move(c.direction, getPlayerTile());
+            if (p.first){
+                playerCoords = playerCoords + getCoords(c.direction); 
+            }
+            return p.second;
+        }
+        default:
+            return "some other action \n";
+    }
 }

--- a/gameModel.h
+++ b/gameModel.h
@@ -39,6 +39,7 @@ class GameModel {
     Enemy* getRandomEnemy(bool hasCompass);
     Tile* getRandomNeighbour(const Tile& current);
     void setPotionVis();
+    Tile& getPlayerTile();
 
     pair<int, int> playerCoords;
     int chamberCount;

--- a/items/item.cc
+++ b/items/item.cc
@@ -11,3 +11,7 @@ Item::~Item(){
 void Item::unlock(){
     isUnlocked = true;
 }
+
+bool Item::getUnlocked(){
+    return isUnlocked;
+}

--- a/items/item.h
+++ b/items/item.h
@@ -7,8 +7,10 @@ using namespace std;
 
 class Item : public Entity{
     bool isUnlocked;
+    protected:
     virtual void applyItemEffect(Player& p) =0;
     public:
+    bool getUnlocked();
     void unlock();
     Item(char c, bool isUnlocked = true);
     virtual ~Item();

--- a/items/steppableItem.cc
+++ b/items/steppableItem.cc
@@ -8,11 +8,11 @@ SteppableItem::~SteppableItem(){
     
 }
 
-// void Item::onStepped(Player& p){
-//     applyItemEffect(p);
-//     die();
-// }
+void SteppableItem::onStepped(Player& p){
+    applyItemEffect(p);
+    die();
+}
 
-// bool SteppableItem::isPassable(){
-//     return (boss == null)
-// }
+bool SteppableItem::isPassable(){
+    return getUnlocked();
+}

--- a/items/steppableItem.h
+++ b/items/steppableItem.h
@@ -7,8 +7,8 @@ using namespace std;
 
 class SteppableItem : public Item {
     public:
-    // void onStepped(Player& p);
-    // virtual bool isPassable() override;
+    void onStepped(Player& p);
+    virtual bool isPassable() override;
     SteppableItem(char c, bool isUnlocked = true);
     virtual ~SteppableItem();
 };

--- a/tile.cc
+++ b/tile.cc
@@ -22,10 +22,12 @@ void Tile::setChamberNum(int n) {
 }
 
 bool Tile::isPassable() {
-    if (c == '#' || c == '\\' || c == '.') {
-        return true;
+    bool tilePassable = false;
+    if (c == '#' || c == '\\' || c == '.' || c == '+') {
+        tilePassable = true;
     }
-    return false;
+    
+    return entity ? tilePassable && entity->isPassable() : tilePassable;
 }
 
 void Tile::setNeighbour(Direction d, Tile* t) {
@@ -37,8 +39,13 @@ const map<Direction, Tile*>& Tile::getNeighbours() const {
 }
 
 void Tile::notify() {
-    char corpse = entity->getChar();
-    // check dragon hoard
+    //cout << "tile notified of death" << endl;
+    Entity* e = getEntity();
+    if(e){
+        //cout << "deleting entity" << endl;
+        delete e;
+    }
+    setEntity(nullptr);
 }
 
 Entity* Tile::getEntity() {

--- a/view.h
+++ b/view.h
@@ -72,11 +72,11 @@ public:
 
             cout << RESET << endl;
         }
-        // cout << "Race: " << p->getRace() << "Gold: " << p->getGold() << "         Floor: " << floor << endl;
-        // cout << "HP: " << p->getHp() << endl;
-        // cout << "Atk: " << p->getAtk() << endl;
-        // cout << "Def: " << p->getDef() << endl;
-        // cout << "Action: " << actionString;
+        cout << "Race: " << p->getRace() << " Gold: " << p->getGold() << "         Floor: " << floor << endl;
+        cout << "HP: " << p->getHp() << endl;
+        cout << "Atk: " << p->getAttack() << endl;
+        cout << "Def: " << p->getDefense() << endl;
+        cout << "Action: " << actionString;
     }
 };
 


### PR DESCRIPTION
Character has a moveNoChecks function that will move the character in a direction. Should only be called when there is no entity in the target tile. Player and Enemy will call this in their move functions. 

Character.move now returns a bool and a string. bool indicates success and the string is for the view. Might want to do this for use and attack as well.

When the player tries to move to a tile it will check if it is passable. If it is passable we do another check to see if there is a steppable item on the tile and if there is we trigger its effect. Theoretically there are no memory leaks.

addToRandom tile also attaches the tile to the entity now